### PR TITLE
added log scale toggle for scatterplot

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -93,12 +93,24 @@ app.layout = dbc.Container([
             ),
 
             dbc.Card(
-                html.Iframe(
+                dbc.CardBody([
+                    html.Iframe(
                     id='scatter-plot',
-                    style={'width': '100%', 'height': '350px', 'border': 'none'}
-                ),
+                    style={'width': '100%', 'height': '292px', 'border': 'none'}
+                    ),
+                dcc.RadioItems(
+                    id='scale-radio',
+                    options=[
+                    {'label': 'Linear', 'value': 'linear'},
+                    {'label': 'Logarithmic', 'value': 'log'},
+                    ],
+                    value='linear',
+                    inline=True,
+                    style={'display': 'flex', 'gap': '15px'}
+                    )   
+                ]),
                 style={'border': '1px solid #ddd', 'padding': '10px'}
-            )
+            ),
         ], style={'padding': '10px', 'backgroundColor': '#fff8dc'}),
     ]),
 

--- a/src/callbacks/charts.py
+++ b/src/callbacks/charts.py
@@ -41,9 +41,10 @@ def register_chart_callbacks(app, issues, issues_values_joined, property_values)
     # Callback for scatter plot
     @app.callback(
         Output('scatter-plot', 'srcDoc'),
-        Input('region-dropdown', 'value')
+        Input('region-dropdown', 'value'),
+        Input('scale-radio','value')
     )
-    def update_scatter_plot(selected_region):
+    def update_scatter_plot(selected_region,selected_scale):
         """Update the scatter plot based on the selected region."""
 
         if selected_region:
@@ -56,7 +57,8 @@ def register_chart_callbacks(app, issues, issues_values_joined, property_values)
             x_col='current_land_value',
             y_col='total_outstanding',
             title='Property Prices vs Outstanding Issues',
+            scale_type=selected_scale,
             x_title='Property Prices',
-            y_title='Outstanding Issues'
+            y_title='Outstanding Issues',  
         )
         return chart.to_html()

--- a/src/components/charts.py
+++ b/src/components/charts.py
@@ -70,7 +70,7 @@ def create_bar_chart(data, x_col, y_col, title, x_title=None, y_title=None):
     return chart
 
 # Create scatter plot
-def create_scatter_plot(data, x_col, y_col, title, x_title=None, y_title=None):
+def create_scatter_plot(data, x_col, y_col, title,scale_type,x_title=None, y_title=None):
     """Create a scatter plot with regression line using Altair library for rental property data."""
 
     if x_title is None:
@@ -82,6 +82,7 @@ def create_scatter_plot(data, x_col, y_col, title, x_title=None, y_title=None):
         y=alt.Y(y_col, title=y_title)
                 .axis(tickMinStep=1,format='d'),
         x=alt.X(x_col, title=x_title)
+                .scale(type=scale_type)
                 .axis(format='$,.0f'),
         color=alt.Color('geo_local_area:N') 
                 .scale(
@@ -93,6 +94,9 @@ def create_scatter_plot(data, x_col, y_col, title, x_title=None, y_title=None):
             alt.Tooltip('geo_local_area:N',title='Neighbourhood'),
             alt.Tooltip('total_units:Q',title='Number of Units')
             ]
+    ).properties(
+        width=320,
+        height=200
     )
 
     fit_line = alt.Chart(data).transform_regression(


### PR DESCRIPTION
Implemented #53, scatterplot has a radio button to toggle log and linear scale. Also resized to fit in one page with the toggle.

<img width="1440" alt="Screenshot 2025-03-09 at 2 33 18 PM" src="https://github.com/user-attachments/assets/002863ed-5089-45bb-b3c5-724e55cf6913" />
